### PR TITLE
Enhances ch2 circus example

### DIFF
--- a/ch2/making-sense-of-channels/example_10/main.go
+++ b/ch2/making-sense-of-channels/example_10/main.go
@@ -2,41 +2,72 @@ package main
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
 
 func main() {
 	clownChannel := make(chan int, 3)
-	clowns := 5
+	driverChannel := make(chan struct{})
+	clowns := 10
+	circusRoundTrip := time.Second * 2 // How long the car takes to go around the circus
 
-	// senders and receivers logic here!
-	var wg sync.WaitGroup
-	wg.Wait()
-	fmt.Println("Circus car ride is over!")
-
+	fmt.Println("Announcer: The circus car is ready for clowns!")
+	// The Driver is waiting for clowns to drive around.
+	// They will wait until there are no more clowns. In other words, clownChannel is closed.
 	go func() {
-		defer close(clownChannel)
-		for clownID := range clownChannel {
-			balloon := fmt.Sprintf("Balloon %d", clownID)
+		// Receiving balls
+		for ball := range clownChannel {
+			balloon := fmt.Sprintf("Balloon %d", ball)
 			fmt.Printf("Driver: Drove the car with %s inside\n", balloon)
-			time.Sleep(time.Millisecond * 500)
+			time.Sleep(circusRoundTrip)
 			fmt.Printf("Driver: Clown finished with %s, the car is ready for more!\n", balloon)
 		}
+
+		fmt.Println("Driver: There is no more clowns to drive around! I'm done for the day!")
+		driverChannel <- struct{}{}
 	}()
 
+	// Clowns are trying to get into the car.
+	// They will keep trying in their own goroutine until they get in.
+	wg := sync.WaitGroup{}
+	wg.Add(clowns)
 	for clown := 1; clown <= clowns; clown++ {
-		wg.Add(1)
 		go func(clownID int) {
 			defer wg.Done()
+
 			balloon := fmt.Sprintf("Balloon %d", clownID)
-			fmt.Printf("Clown %d: Hopped into the car with %s\n", clownID, balloon)
-			select {
-			case clownChannel <- clownID:
-				fmt.Printf("Clown %d: Finished with %s\n", clownID, balloon)
-			default:
-				fmt.Printf("Clown %d: Oops, the car is full, can't fit %s!\n", clownID, balloon)
+			for {
+				select {
+				case clownChannel <- clownID:
+					fmt.Printf("Clown %d: Hopping into the car with %s\n", clownID, balloon)
+					return
+				default:
+					fmt.Printf("Clown %d: Oops, the car is full, can't fit %s!\n", clownID, balloon)
+				}
+				retry()
 			}
 		}(clown)
 	}
+
+	// Announcer is waiting for all clowns start battling for a car spot.
+	// They will wait until all clowns are done trying to get in the car.
+	// In other words, the WaitGroup is done.
+	// Once all clowns are done, the clownChannel is closed.
+	go func() {
+		fmt.Println("Announcer: All clowns are battling for the car!")
+		wg.Wait()
+		close(clownChannel)
+	}()
+
+	// Wait for the driver to finish driving all clowns around.
+	<-driverChannel
+	fmt.Println("Circus car ride is over!")
+}
+
+// retry is a function that simulates the clowns trying to get in the car chaotically
+// by sleeping for a random amount of time between 2000 and 10000 milliseconds
+func retry() {
+	time.Sleep(time.Duration(max(rand.IntN(10000), 2000)) * time.Millisecond)
 }


### PR DESCRIPTION
This PR enhances the circus car ride example in `ch2/making-sense-of-channels/example_10/main.go`. The changes introduce a more dynamic simulation where clowns continuously attempt to enter a car until they succeed. The driver waits until all clowns have taken a ride, and the announcer oversees the entire scenario. 

Timing and concurrency are improved to showcase how goroutines and channels can synchronize multiple actors in a more realistic manner.

Key Changes:
- Increased the number of clowns from 5 to 10.
- Introduced a `driverChannel` to signal when the driver is finished.
-  The driver now simulates a "round trip" using a configurable delay (`circusRoundTrip`).
- Enhanced the logic so clowns keep trying to enter the car if it’s full, using a `retry()` function to add randomness to their attempts.
- Added a wait group (`sync.WaitGroup`) to ensure the announcer waits for all clowns to have attempted entry before closing the `clownChannel`.
- Overall, refactored the flow to be more illustrative of concurrent patterns and resource contention using channels.


## Notes

- The `retry()` function uses `math/rand/v2` to add randomness and simulate unpredictable attempts by the clowns to join the car.
- This change aims to make the concurrency example more engaging and to illustrate backpressure and contention handling with channels.