### PR TITLE
Ch2 fix example4

### DIFF
--- a/ch2/changing-shared-state/example_4/main.go
+++ b/ch2/changing-shared-state/example_4/main.go
@@ -1,21 +1,13 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
 
 func main() {
-	times := 0
-
-	for {
-		times++
-		counter := PackItems(0)
-		if counter != 2000 {
-			log.Fatalf("it should be 2000 but found %d on execution %d", counter, times)
-		}
-	}
+	fmt.Println("Total Items Packed:", PackItems(0))
 }
 
 func PackItems(totalItems int32) int32 {

--- a/ch2/changing-shared-state/example_4/main.go
+++ b/ch2/changing-shared-state/example_4/main.go
@@ -34,13 +34,13 @@ func PackItems(totalItems int32) int32 {
 			for j := 0; j < itemsPerWorker; j++ {
 				atomic.AddInt32(&itemsPacked, 1)
 			}
-			atomic.SwapInt32(&totalItems, itemsPacked)
 		}(i)
 
 	}
 
 	// Wait for all workers to finish.
 	wg.Wait()
+	atomic.SwapInt32(&totalItems, itemsPacked)
 
 	return totalItems
 }

--- a/ch2/changing-shared-state/example_4/main_test.go
+++ b/ch2/changing-shared-state/example_4/main_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestPackItems(t *testing.T) {
-	totalItems := PackItems(2000)
+	totalItems := PackItems(0)
 	expectedTotal := int32(2000)
 	if totalItems != expectedTotal {
 		t.Errorf("Expected total: %d, Actual total: %d", expectedTotal, totalItems)


### PR DESCRIPTION
Fixes data race conditions in example 4 (Chapter 2).

The atomic.SwapInt32(&totalItems, itemsPacked) call must come after wg.Wait(). Otherwise, each worker overwrites the total with its own itemsPacked value (e.g., both set it to 1000), leading to incorrect results.

I spotted this while working through Chapter 2. It builds on a similar issue noted in January by @zjfsdnu in this closed issue comment: https://github.com/PacktPublishing/System-Programming-Essentials-with-Go/issues/5#issuecomment-2588836864. (This PR addresses a distinct but related race condition.)

Additional fixes:
* Updated the test case to start at 0 instead of 2000 (the expected end result), so it no longer falsely passes.
* Adjusted the main function to prevent an infinite loop now that the concurrency logic is correct.

Alternative approach (not implemented):
To avoid the itemsPacked variable and atomic.SwapInt32 entirely, we could increment totalItems directly in the loop using atomic.AddInt32. This simplifies the code while maintaining thread safety:
```go
func PackItems(totalItems int32) int32 {
	const workers = 2
	const itemsPerWorker = 1000

	var wg sync.WaitGroup

	for i := 0; i < workers; i++ {
		wg.Add(1)

		go func(workerID int) {
			defer wg.Done()
			// Simulate the worker packing items into boxes.
			for j := 0; j < itemsPerWorker; j++ {
				atomic.AddInt32(&totalItems, 1)
			}
		}(i)

	}

	// Wait for all workers to finish.
	wg.Wait()

	return totalItems
}
```

I opted to move the SwapInt32 instead, to align with the approach from prior commits merged in issue #5.
Let me know if the alternative makes more sense or if there's another way to handle this!