### PR TITLE
Tests should start with 0 packed items in chapter 2

### DIFF
--- a/ch2/changing-shared-state/example_3/main_test.go
+++ b/ch2/changing-shared-state/example_3/main_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestPackItems(t *testing.T) {
-	totalItems := PackItems(2000)
+	totalItems := PackItems(0)
 	expectedTotal := 2000
 	if totalItems != expectedTotal {
 		t.Errorf("Expected total: %d, Actual total: %d", expectedTotal, totalItems)

--- a/ch2/changing-shared-state/example_4/main_test.go
+++ b/ch2/changing-shared-state/example_4/main_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestPackItems(t *testing.T) {
-	totalItems := PackItems(2000)
+	totalItems := PackItems(0)
 	expectedTotal := int32(2000)
 	if totalItems != expectedTotal {
 		t.Errorf("Expected total: %d, Actual total: %d", expectedTotal, totalItems)

--- a/ch2/changing-shared-state/example_5/main_test.go
+++ b/ch2/changing-shared-state/example_5/main_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPackItems(t *testing.T) {
 	m := sync.Mutex{}
-	totalItems := PackItems(&m, 2000)
+	totalItems := PackItems(&m, 0)
 	expectedTotal := 2000
 	if totalItems != expectedTotal {
 		t.Errorf("Expected total: %d, Actual total: %d", expectedTotal, totalItems)


### PR DESCRIPTION
Tests in chapter 2 start with `totalItems := PackItems(2000)` which 2000 is the value we are trying to match from our expectedTotal. This leads to failing tests with error
```
--- FAIL: TestPackItems (0.00s)
    main_test.go:13: Expected total: 2000, Actual total: 4000
```

The PackedItems should be starting with 0 for proper testing.

